### PR TITLE
Use joinpath and homedir instead of expanduser so it will work on windows

### DIFF
--- a/src/feed/quandl.jl
+++ b/src/feed/quandl.jl
@@ -8,10 +8,10 @@ import HTTP
 Set up Quandl user account authorization. Run once passing your Quandl API key, and it will be saved for future use.
 
 
-    quandl_auth(key::String=""; authfile::String=expanduser("~/quandl-auth"))::String
+    quandl_auth(key::String=""; authfile::String=joinpath(homedir(),"quandl-auth"))::String
 
 """
-function quandl_auth(key::String=""; authfile::String=expanduser("~/quandl-auth"))::String
+function quandl_auth(key::String=""; authfile::String=joinpath(homedir(),"quandl-auth"))::String
     if key == ""
         if isfile(authfile)
             key = read(authfile, String)


### PR DESCRIPTION
Tested this change and it works as intended on Windows. I tested on WSL2 to make sure it all still worked on linux as well.