### PR TITLE
Fix some bugs in the `tsread` function

### DIFF
--- a/src/feed/text.jl
+++ b/src/feed/text.jl
@@ -31,7 +31,7 @@ function tsread(file::String; dlm::Char=',', header::Bool=true, eol::Char='\n', 
         # k = matchcount(csv[1], dlm)
         k = sum([csv[1][i] == dlm for i in 1:length(csv[1])])
         n = length(csv)
-        fields = autocolname(1:k)
+        fields = autocol(1:k)
     end
     # Fill data
     arr = zeros(Float64, (n,k))
@@ -44,7 +44,7 @@ function tsread(file::String; dlm::Char=',', header::Bool=true, eol::Char='\n', 
             arr[i,j] = parse(Float64, s[j])
         end
     end
-    return TS(arr, indextype.(idx), fields)
+    return TS(arr, indextype.(idx, format), fields)
 end
 
 """

--- a/test/data.jl
+++ b/test/data.jl
@@ -9,6 +9,10 @@ using Test, Dates, Temporal
         @test filepath in readdir()
         b = tsread(filepath)
         @test a == b
+
+        filepath = "../data/XOM.csv"
+        c = tsread(filepath, format="yyyy-mm-dd")
+        @test c[:Open].values[1] == 1.929688
     end
     @testset "Web Downloads" begin
         @testset "Quandl" begin


### PR DESCRIPTION
Two minor bug fixes:
- The `autocolname` has been changed to `autocol`, in accordance with the `utils.jl`
- Passing `format` argument to the index constructor.